### PR TITLE
Add release Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+on: 
+  release:
+    types: [published,edited]
+name: Build Release
+jobs:
+  release-linux-amd64:
+    name: release linux/amd64
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.14.x
+    - name: compile and release
+      run: |
+        ./ci-build.sh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GOARCH: amd64
+        GOOS: linux
+
+  release-linux-386:
+    name: release linux/386
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.14.x
+    - name: compile and release
+      run: |
+        ./ci-build.sh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GOARCH: "386"
+        GOOS: linux
+
+  release-darwin-amd64:
+    name: release darwin/amd64
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.14.x
+    - name: compile and release
+      run: |
+        ./ci-build.sh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GOARCH: amd64
+        GOOS: darwin

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -eux
+
+EVENT_DATA=$(cat $GITHUB_EVENT_PATH)
+echo $EVENT_DATA | jq .
+UPLOAD_URL=$(echo $EVENT_DATA | jq -r .release.upload_url)
+UPLOAD_URL=${UPLOAD_URL/\{?name,label\}/}
+RELEASE_NAME=$(echo $EVENT_DATA | jq -r .release.tag_name)
+PROJECT_NAME=$(basename $GITHUB_REPOSITORY)
+NAME="${NAME:-${PROJECT_NAME}_${RELEASE_NAME}}_${GOOS}_${GOARCH}"
+
+go build .
+
+ARCHIVE=tmp.tar.gz
+FILE_LIST=goc
+tar cvfz $ARCHIVE ${FILE_LIST}
+
+CHECKSUM=$(md5sum ${ARCHIVE} | cut -d ' ' -f 1)
+
+curl \
+  -X POST \
+  --data-binary @${ARCHIVE} \
+  -H 'Content-Type: application/octet-stream' \
+  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  "${UPLOAD_URL}?name=${NAME}.${ARCHIVE/tmp./}"
+
+curl \
+  -X POST \
+  --data $CHECKSUM \
+  -H 'Content-Type: text/plain' \
+  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  "${UPLOAD_URL}?name=${NAME}_checksum.txt"

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -8,7 +8,7 @@ UPLOAD_URL=$(echo $EVENT_DATA | jq -r .release.upload_url)
 UPLOAD_URL=${UPLOAD_URL/\{?name,label\}/}
 RELEASE_NAME=$(echo $EVENT_DATA | jq -r .release.tag_name)
 PROJECT_NAME=$(basename $GITHUB_REPOSITORY)
-NAME="${NAME:-${PROJECT_NAME}_${RELEASE_NAME}}_${GOOS}_${GOARCH}"
+NAME="${NAME:-${PROJECT_NAME}-${RELEASE_NAME}}-${GOOS}-${GOARCH}"
 
 go build .
 

--- a/ci-build.sh
+++ b/ci-build.sh
@@ -30,4 +30,4 @@ curl \
   --data $CHECKSUM \
   -H 'Content-Type: text/plain' \
   -H "Authorization: Bearer ${GITHUB_TOKEN}" \
-  "${UPLOAD_URL}?name=${NAME}_checksum.txt"
+  "${UPLOAD_URL}?name=${NAME}_md5.txt"


### PR DESCRIPTION
This new action will cross-compile the binary on the following platforms:
1. linux-386
2. linux-amd64
3. darwin-amd64

The action will be triggered once the goc release is published or editted.

Name convention:
goc-$tag-${GOOS}-${GOARCH}

Example:
https://github.com/lyyyuna/goc-1/releases/tag/v0.9.4