### PR TITLE
support for new packages that need downloading.

### DIFF
--- a/pkg/cover/cover.go
+++ b/pkg/cover/cover.go
@@ -259,12 +259,14 @@ func ListPackages(dir string, args string, newgopath string) (map[string]*Packag
 	if newgopath != "" {
 		cmd.Env = append(os.Environ(), fmt.Sprintf("GOPATH=%v", newgopath))
 	}
-	out, err := cmd.CombinedOutput()
+	var errbuf bytes.Buffer
+	cmd.Stderr = &errbuf
+	out, err := cmd.Output()
 	if err != nil {
-		log.Errorf("excute `go list -json ./...` command failed, err: %v, out: %v", err, string(out))
+		log.Errorf("excute `go list -json ./...` command failed, err: %v, stdout: %v, stderr: %v", err, string(out), errbuf.String())
 		return nil, ErrCoverListFailed
 	}
-
+	log.Infof("\n%v", errbuf.String())
 	dec := json.NewDecoder(bytes.NewReader(out))
 	pkgs := make(map[string]*Package, 0)
 	for {


### PR DESCRIPTION
fix #50 

1. for wrong project, capture error exit
```
INFO[2020-07-03T22:28:02+08:00][cover/cover.go:257] go list cmd is: [/bin/bash -c go list -json ./...]
ERRO[2020-07-03T22:28:02+08:00][cover/cover.go:266] excute `go list -json ./...` command failed, err: exit status 1, stdout: , stderr: can't load package: package mmtelegram:
main.go:8:1: rune literal not terminated
```

2. for project first built, print out go downloading progress
```
INFO[2020-07-03T22:08:58+08:00][cover/cover.go:257] go list cmd is: [/bin/bash -c go list -json ./...]
INFO[2020-07-03T22:09:01+08:00][cover/cover.go:269]
go: downloading github.com/go-telegram-bot-api/telegram-bot-api v4.6.4+incompatible
go: downloading github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
go: downloading github.com/parnurzeal/gorequest v0.2.15
go: downloading golang.org/x/net v0.0.0-20190311183353-d8887717615a
go: downloading github.com/moul/http2curl v1.0.0
go: downloading github.com/pkg/errors v0.8.1
go: downloading github.com/technoweenie/multipartstreamer v1.0.1
```