### PR TITLE
support goc version using `go get`

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"fmt"
+	"runtime/debug"
 
 	"github.com/spf13/cobra"
 )
@@ -33,7 +34,15 @@ var versionCmd = &cobra.Command{
 goc version
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(version)
+		// if it is "Unstable", means user build local or with go get
+		if version == "Unstable" {
+			if info, ok := debug.ReadBuildInfo(); ok {
+				fmt.Println(info.Main.Version)
+			}
+		} else {
+			// otherwise the value is injected in CI
+			fmt.Println(version)
+		}
 	},
 }
 


### PR DESCRIPTION
1. install with go get (auto-version branch has latest code)
```
$ go get -u github.com/qiniu/goc@auto-version

$ goc version
v1.0.2-0.20200704073344-bc3968fc06bb
```

2. install/build in local
```
$ goc version
(devel)
```

3. binary downloaded in release page, for example:
```
➜  ~ wget https://github.com/lyyyuna/goc-1/releases/download/v0.9.5/goc-1-v0.9.5-linux-amd64.tar.gz
.....
➜  ~ tar xvf goc-1-v0.9.5-linux-amd64.tar.gz
goc
➜  ~ ./goc version
v0.9.5
```
