### PR TITLE
Add some e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,11 @@ fmt:
 
 govet-check:
 	go vet ./...
+
+clean:
+	find tests/ -type f -name '*.bak' -delete 
+	find tests/ -type f -name '*.cov' -delete 
+	find tests/ -type f -name 'simple-project' -delete 
+	find tests/ -type f -name '*_profile_listen_addr' -delete 
+	find tests/ -type f -name 'simple_gopath_project' -delete 
+	

--- a/cmd/commonflags.go
+++ b/cmd/commonflags.go
@@ -25,11 +25,12 @@ import (
 )
 
 var (
-	target     string
-	center     string
-	agentPort  AgentPort
-	debugGoc   bool
-	buildFlags string
+	target            string
+	center            string
+	agentPort         AgentPort
+	debugGoc          bool
+	debugInCISyncFile string
+	buildFlags        string
 
 	goRunExecFlag  string
 	goRunArguments string

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -18,8 +18,9 @@ package cmd
 
 import (
 	"fmt"
-	"log"
 	"os"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/qiniu/goc/pkg/cover"
 	"github.com/spf13/cobra"
@@ -37,6 +38,7 @@ goc list [flags]
 		if err != nil {
 			log.Fatalf("list failed, err: %v", err)
 		}
+		log.Infoln(string(res))
 		fmt.Fprint(os.Stdout, string(res))
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,9 +17,11 @@
 package cmd
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -58,10 +60,23 @@ Find more information at:
 			})
 		}
 	},
+	PersistentPostRun: func(cmd *cobra.Command, args []string) {
+		if debugInCISyncFile != "" {
+			f, err := os.Create(debugInCISyncFile)
+			if err != nil {
+				log.Fatalln(err)
+			}
+			defer f.Close()
+
+			time.Sleep(5 * time.Second)
+		}
+	},
 }
 
 func init() {
 	rootCmd.PersistentFlags().BoolVar(&debugGoc, "debug", false, "run goc in debug mode")
+	rootCmd.PersistentFlags().StringVar(&debugInCISyncFile, "debugcisyncfile", "", "internal use only, no explain")
+	rootCmd.PersistentFlags().MarkHidden("debugcisyncfile")
 	viper.BindPFlags(rootCmd.PersistentFlags())
 }
 

--- a/pkg/build/run.go
+++ b/pkg/build/run.go
@@ -39,12 +39,10 @@ func (b *Build) Run() error {
 	cmd.Stderr = os.Stderr
 	err := cmd.Start()
 	if err != nil {
-		log.Errorf("Fail to start command: %v. The error is: %v", cmd.Args, err)
 		return fmt.Errorf("fail to execute: %v, err: %w", cmd.Args, err)
 	}
 
 	if err = cmd.Wait(); err != nil {
-		log.Errorf("Fail to go run: %v. The error is: %v", cmd.Args, err)
 		return fmt.Errorf("fail to execute: %v, err: %w", cmd.Args, err)
 	}
 

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -31,7 +31,7 @@ teardown_file() {
 
 @test "test basic goc build command" {
     cd samples/run_for_several_seconds
-    wait_profile_backend "build"
+    wait_profile_backend "build1"
     run gocc build --debug --debugcisyncfile ci-sync.bak;
     info build output: $output
     [ "$status" -eq 0 ]
@@ -39,7 +39,7 @@ teardown_file() {
 
 @test "test goc build command without debug" {
     cd samples/run_for_several_seconds
-    wait_profile_backend "build"
+    wait_profile_backend "build2"
     run gocc build --debugcisyncfile ci-sync.bak;
     info build output: $output
     [ "$status" -eq 0 ]

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -22,24 +22,25 @@ setup_file() {
     sleep 2
     goc init
 
-    # run covered goc run
-    WORKDIR=$PWD
-    cd samples/run_for_several_seconds
-    ls -al
-    gocc run --debug . 3>&- &
-    GOCC_PID=$!
-    sleep 2
-    info "goc gocc server started"
+    info "goc server started"
 }
 
 teardown_file() {
-    cd $WORKDIR
-    # collect from center
-    goc profile --debug -o filtered-run.cov
     kill -9 $GOC_PID
-    kill -9 $GOCC_PID
 }
 
-@test "test basic goc run" {
+@test "test basic goc build command" {
+    cd samples/run_for_several_seconds
+    wait_profile_backend "build"
+    run gocc build --debug --debugcisyncfile ci-sync.bak;
+    info build output: $output
+    [ "$status" -eq 0 ]
+}
 
+@test "test goc build command without debug" {
+    cd samples/run_for_several_seconds
+    wait_profile_backend "build"
+    run gocc build --debugcisyncfile ci-sync.bak;
+    info build output: $output
+    [ "$status" -eq 0 ]
 }

--- a/tests/clear.bats
+++ b/tests/clear.bats
@@ -22,24 +22,41 @@ setup_file() {
     sleep 2
     goc init
 
-    # run covered goc run
+    # run covered goc
+    gocc server --port=:60001 --debug 3>&- &
+    GOCC_PID=$!
+    sleep 1
+
     WORKDIR=$PWD
     cd samples/run_for_several_seconds
-    ls -al
-    gocc run --debug . 3>&- &
-    GOCC_PID=$!
+    gocc build --center=http://127.0.0.1:60001
+    ./simple-project 3>&- &
+    SAMPLE_PID=$!
     sleep 2
-    info "goc gocc server started"
+
+    info "goc server started"
 }
 
 teardown_file() {
-    cd $WORKDIR
-    # collect from center
-    goc profile --debug -o filtered-run.cov
     kill -9 $GOC_PID
     kill -9 $GOCC_PID
+    kill -9 $SAMPLE_PID
 }
 
-@test "test basic goc run" {
+@test "test basic goc clear command" {
+    wait_profile_backend "clear1"
 
+    run gocc clear --debug --debugcisyncfile ci-sync.bak;
+    info clear1 output: $output
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"coverage counter clear call successfully"* ]]
+}
+
+@test "test clear another center" {
+    wait_profile_backend "clear2"
+
+    run gocc clear --center=http://127.0.0.1:60001 --debug --debugcisyncfile ci-sync.bak;
+    info clear2 output: $output
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"coverage counter clear call successfully"* ]]
 }

--- a/tests/diff.bats
+++ b/tests/diff.bats
@@ -1,0 +1,69 @@
+#!/usr/bin/env bats
+# Copyright 2020 Qiniu Cloud (七牛云)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load util.sh
+
+setup_file() {
+    # run centered server
+    goc server 3>&- &
+    GOC_PID=$!
+    sleep 2
+    goc init
+
+    info "goc server started"
+}
+
+teardown_file() {
+    kill -9 $GOC_PID
+}
+
+@test "test basic goc diff command" {
+    cd samples/diff_samples
+
+    wait_profile_backend "diff1"
+
+
+    run gocc diff --new-profile=./new.voc --base-profile=./base.voc --debug --debugcisyncfile ci-sync.bak;
+    info list output: $output
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"qiniu.com/kodo/apiserver/server/main.go |     50.0%     |    100.0%    | 50.0%"* ]]
+    [[ "$output" == *"Total                                   |     50.0%     |    100.0%    | 50.0%"* ]]
+}
+
+@test "test diff in prow environment with periodic job" {
+    cd samples/diff_samples
+
+    wait_profile_backend "diff2"
+
+    export JOB_TYPE=periodic
+
+    run gocc diff --new-profile=./new.voc --prow-postsubmit-job=base --debug --debugcisyncfile ci-sync.bak;
+    info diff1 output: $output
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"do nothing"* ]]
+}
+
+@test "test diff in prow environment with postsubmit job" {
+    cd samples/diff_samples
+
+    wait_profile_backend "diff3"
+
+    export JOB_TYPE=postsubmit
+
+    run gocc diff --new-profile=./new.voc --prow-postsubmit-job=base --debug --debugcisyncfile ci-sync.bak;
+    info diff2 output: $output
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"do nothing"* ]]
+}

--- a/tests/init.bats
+++ b/tests/init.bats
@@ -22,24 +22,31 @@ setup_file() {
     sleep 2
     goc init
 
-    # run covered goc run
+    # run covered goc
+    gocc server --port=:60001 --debug 3>&- &
+    GOCC_PID=$!
+    sleep 1
+
     WORKDIR=$PWD
     cd samples/run_for_several_seconds
-    ls -al
-    gocc run --debug . 3>&- &
-    GOCC_PID=$!
+    gocc build --center=http://127.0.0.1:60001
+    ./simple-project 3>&- &
+    SAMPLE_PID=$!
     sleep 2
-    info "goc gocc server started"
+
+    info "goc server started"
 }
 
 teardown_file() {
-    cd $WORKDIR
-    # collect from center
-    goc profile --debug -o filtered-run.cov
     kill -9 $GOC_PID
     kill -9 $GOCC_PID
+    kill -9 $SAMPLE_PID
 }
 
-@test "test basic goc run" {
+@test "test init command" {
+    wait_profile_backend "init1"
 
+    run gocc init --center=http://127.0.0.1:60001 --debug --debugcisyncfile ci-sync.bak;
+    info init output: $output
+    [ "$status" -eq 0 ]
 }

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -22,24 +22,20 @@ setup_file() {
     sleep 2
     goc init
 
-    # run covered goc run
-    WORKDIR=$PWD
-    cd samples/run_for_several_seconds
-    ls -al
-    gocc run --debug . 3>&- &
-    GOCC_PID=$!
-    sleep 2
-    info "goc gocc server started"
+    info "goc server started"
 }
 
 teardown_file() {
-    cd $WORKDIR
-    # collect from center
-    goc profile --debug -o filtered-run.cov
     kill -9 $GOC_PID
-    kill -9 $GOCC_PID
 }
 
-@test "test basic goc run" {
-
+@test "test basic goc install command" {
+    info $PWD
+    export GOPATH=$PWD/samples/simple_gopath_project
+    export GO111MODULE=off
+    cd samples/simple_gopath_project/src/qiniu.com/simple_gopath_project
+    wait_profile_backend "install"
+    run gocc install --debug --debugcisyncfile ci-sync.bak;
+    info install output: $output
+    [ "$status" -eq 0 ]
 }

--- a/tests/list.bats
+++ b/tests/list.bats
@@ -22,24 +22,25 @@ setup_file() {
     sleep 2
     goc init
 
-    # run covered goc run
-    WORKDIR=$PWD
-    cd samples/run_for_several_seconds
-    ls -al
-    gocc run --debug . 3>&- &
+    # run covered goc
+    gocc server --port=:60001 --debug 3>&- &
     GOCC_PID=$!
-    sleep 2
-    info "goc gocc server started"
+    sleep 1
+
+    info "goc server started"
 }
 
 teardown_file() {
-    cd $WORKDIR
-    # collect from center
-    goc profile --debug -o filtered-run.cov
     kill -9 $GOC_PID
     kill -9 $GOCC_PID
 }
 
-@test "test basic goc run" {
+@test "test basic goc list command" {
+    wait_profile_backend "list"
 
+    run gocc list --debug --debugcisyncfile ci-sync.bak;
+    info list output: $output
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"gocc"* ]]
+    [[ "$output" == *"http"* ]]
 }

--- a/tests/profile.bats
+++ b/tests/profile.bats
@@ -22,24 +22,32 @@ setup_file() {
     sleep 2
     goc init
 
-    # run covered goc run
-    WORKDIR=$PWD
-    cd samples/run_for_several_seconds
-    ls -al
-    gocc run --debug . 3>&- &
+    # run covered goc
+    gocc server --port=:60001 --debug 3>&- &
     GOCC_PID=$!
-    sleep 2
-    info "goc gocc server started"
+    sleep 1
+
+    info "goc server started"
 }
 
 teardown_file() {
-    cd $WORKDIR
-    # collect from center
-    goc profile --debug -o filtered-run.cov
     kill -9 $GOC_PID
     kill -9 $GOCC_PID
 }
 
-@test "test basic goc run" {
+@test "test goc profile to stdout" {
+    wait_profile_backend "profile1"
 
+    run gocc profile --debug --debugcisyncfile ci-sync.bak;
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"mode: count"* ]]
+}
+
+@test "test goc profile to file" {
+    wait_profile_backend "profile2"
+
+    run gocc profile -o test-profile.bak --debug --debugcisyncfile ci-sync.bak;
+    [ "$status" -eq 0 ]
+    run cat test-profile.bak
+    [[ "$output" == *"mode: count"* ]]
 }

--- a/tests/register.bats
+++ b/tests/register.bats
@@ -22,24 +22,33 @@ setup_file() {
     sleep 2
     goc init
 
-    # run covered goc run
-    WORKDIR=$PWD
-    cd samples/run_for_several_seconds
-    ls -al
-    gocc run --debug . 3>&- &
+    # run covered goc
+    gocc server --port=:60001 --debug 3>&- &
     GOCC_PID=$!
-    sleep 2
-    info "goc gocc server started"
+    sleep 1
+
+    info "goc server started"
 }
 
 teardown_file() {
-    cd $WORKDIR
-    # collect from center
-    goc profile --debug -o filtered-run.cov
     kill -9 $GOC_PID
     kill -9 $GOCC_PID
 }
 
-@test "test basic goc run" {
+@test "test basic goc register command" {
+    wait_profile_backend "register1"
 
+    run gocc register --center=http://127.0.0.1:60001 --name=xyz --address=http://137.0.0.1:666 --debug --debugcisyncfile ci-sync.bak;
+    info register output: $output
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"success"* ]]
+}
+
+@test "test goc register without port" {
+    wait_profile_backend "register2"
+
+    run gocc register --center=http://127.0.0.1:60001 --name=xyz --address=http://137.0.0.1 --debug --debugcisyncfile ci-sync.bak;
+    info register output: $output
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"missing port"* ]]
 }

--- a/tests/run-ci-actions.sh
+++ b/tests/run-ci-actions.sh
@@ -19,7 +19,7 @@ echo "test start"
 
 bats -t server.bats
 
-bats -t gocrun.bats
+bats -t run.bats
 
 bats -t version.bats
 

--- a/tests/run-ci-actions.sh
+++ b/tests/run-ci-actions.sh
@@ -17,8 +17,28 @@ set -ex
 
 echo "test start"
 
-bats server.bats
+bats -t server.bats
 
-bats gocrun.bats
+bats -t gocrun.bats
+
+bats -t version.bats
+
+bats -t list.bats
+
+bats -t clear.bats
+
+bats -t build.bats
+
+bats -t profile.bats
+
+bats -t install.bats
+
+bats -t register.bats
+
+bats -t init.bats
+
+bats -t diff.bats
+
+bats -t cover.bats
 
 bash <(curl -s https://codecov.io/bash) -f 'filtered*' -F e2e

--- a/tests/run-in-local.sh
+++ b/tests/run-in-local.sh
@@ -17,4 +17,4 @@ set -ex
 
 echo "test start"
 
-bats -t profile.bats
+bats -t run.bats

--- a/tests/run-in-local.sh
+++ b/tests/run-in-local.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bats
+#!/usr/bin/env bash
 # Copyright 2020 Qiniu Cloud (七牛云)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,33 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load util.sh
+set -ex
 
-setup_file() {
-    # run centered server
-    goc server 3>&- &
-    GOC_PID=$!
-    sleep 2
-    goc init
+echo "test start"
 
-    # run covered goc run
-    WORKDIR=$PWD
-    cd samples/run_for_several_seconds
-    ls -al
-    gocc run --debug . 3>&- &
-    GOCC_PID=$!
-    sleep 2
-    info "goc gocc server started"
-}
-
-teardown_file() {
-    cd $WORKDIR
-    # collect from center
-    goc profile --debug -o filtered-run.cov
-    kill -9 $GOC_PID
-    kill -9 $GOCC_PID
-}
-
-@test "test basic goc run" {
-
-}
+bats -t profile.bats

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -22,24 +22,22 @@ setup_file() {
     sleep 2
     goc init
 
-    # run covered goc run
-    WORKDIR=$PWD
-    cd samples/run_for_several_seconds
-    ls -al
-    gocc run --debug . 3>&- &
-    GOCC_PID=$!
-    sleep 2
     info "goc gocc server started"
 }
 
 teardown_file() {
-    cd $WORKDIR
-    # collect from center
-    goc profile --debug -o filtered-run.cov
     kill -9 $GOC_PID
-    kill -9 $GOCC_PID
 }
 
 @test "test basic goc run" {
+    info $PWD
+    export GOPATH=$PWD/samples/simple_gopath_project
+    export GO111MODULE=off
+    cd samples/simple_gopath_project/src/qiniu.com/simple_gopath_project
+    wait_profile_backend "run1"
 
+    run gocc run . --debug --debugcisyncfile ci-sync.bak;
+    info run output: $output
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"hello, world."* ]]
 }

--- a/tests/samples/diff_samples/base.voc
+++ b/tests/samples/diff_samples/base.voc
@@ -1,0 +1,3 @@
+mode: atomic
+qiniu.com/kodo/apiserver/server/main.go:32.49,33.13 1 30
+qiniu.com/kodo/apiserver/server/main.go:42.49,43.13 1 0

--- a/tests/samples/diff_samples/new.voc
+++ b/tests/samples/diff_samples/new.voc
@@ -1,0 +1,3 @@
+mode: atomic
+qiniu.com/kodo/apiserver/server/main.go:32.49,33.13 1 30
+qiniu.com/kodo/apiserver/server/main.go:42.49,43.13 1 1

--- a/tests/server.bats
+++ b/tests/server.bats
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load util.sh
+
 setup_file() {
     # run centered server
     goc server 3>&- &
@@ -23,12 +25,12 @@ setup_file() {
     gocc server --port=:60001 --debug 3>&- &
     GOCC_PID=$!
     sleep 2
-    echo "goc gocc server started"
+    info "goc gocc server started"
 }
 
 teardown_file() {
     # collect from center
-    goc profile --debug -o filtered.cov
+    goc profile --debug -o filtered-server.cov
     kill -9 $GOC_PID
     kill -9 $GOCC_PID
 }

--- a/tests/version.bats
+++ b/tests/version.bats
@@ -22,24 +22,21 @@ setup_file() {
     sleep 2
     goc init
 
-    # run covered goc run
-    WORKDIR=$PWD
-    cd samples/run_for_several_seconds
-    ls -al
-    gocc run --debug . 3>&- &
-    GOCC_PID=$!
-    sleep 2
-    info "goc gocc server started"
+    info "goc server started"
+}
+
+setup() {
+    goc init
+    rm ci-sync.bak || true
 }
 
 teardown_file() {
-    cd $WORKDIR
-    # collect from center
-    goc profile --debug -o filtered-run.cov
     kill -9 $GOC_PID
-    kill -9 $GOCC_PID
 }
 
-@test "test basic goc run" {
+@test "test basic goc version command" {
+    wait_profile_backend "version"
 
+    run gocc version --debug --debugcisyncfile ci-sync.bak;
+    [ "$output" = "(devel)" ]
 }


### PR DESCRIPTION
1.  add a hidden flag (--debugcisyncfile, internal CI use only). It will write a sync file before exit, and sleep 5 seconds. However, it cannot catch panic case. It is mainly used in goc's CI e2e tests.
2. add e2e test cases for subcommand: list/clear/version/build/profile/install/register/init/diff/cover
3. add make clean to clean some test-intermediate-obj.