### PR TITLE
Enhance "file lock sync" logic

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -96,11 +96,9 @@ func (b *Build) Build() error {
 	log.Printf("go build cmd is: %v", cmd.Args)
 	err := cmd.Start()
 	if err != nil {
-		log.Errorf("Fail to execute: %v. The error is: %v", cmd.Args, err)
 		return fmt.Errorf("fail to execute: %v, err: %w", cmd.Args, err)
 	}
 	if err = cmd.Wait(); err != nil {
-		log.Errorf("go build failed. The error is: %v", err)
 		return fmt.Errorf("fail to execute: %v, err: %w", cmd.Args, err)
 	}
 	log.Infoln("Go build exit successful.")
@@ -111,7 +109,6 @@ func (b *Build) Build() error {
 // the binary name is always same as the directory name of current directory
 func (b *Build) determineOutputDir(outputDir string) (string, error) {
 	if b.TmpDir == "" {
-		log.Errorf("Can only be called after Build.MvProjectsToTmp(): %v", ErrWrongCallSequence)
 		return "", fmt.Errorf("can only be called after Build.MvProjectsToTmp(): %w", ErrWrongCallSequence)
 	}
 
@@ -119,8 +116,8 @@ func (b *Build) determineOutputDir(outputDir string) (string, error) {
 	if outputDir != "" {
 		abs, err := filepath.Abs(outputDir)
 		if err != nil {
-			log.Errorf("Fail to transform the path: %v to absolute path: %v", outputDir, err)
-			return "", err
+			return "", fmt.Errorf("Fail to transform the path: %v to absolute path: %v", outputDir, err)
+
 		}
 		return abs, nil
 	}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,51 @@
+# How to write goc e2e test cases
+
+Current goc e2e test is based on the [bats-core](https://github.com/bats-core/bats-core) framework, you should read its document first.
+
+## Local dev requirements
+
+* [bats-core](https://github.com/bats-core/bats-core)
+* install `goc` to `PATH`
+* build `goc` with `goc`, generate the binary `gocc`, install `gocc` to `PATH`
+
+## Test goc
+
+First of all, you should start a `goc server` in `setup_file` function from the backend, 
+
+```
+setup_file() {
+    goc server 3>&- &
+    GOC_PID=$!
+    sleep 2
+    goc init
+}
+```
+
+According to [this](https://github.com/bats-core/bats-core/blob/master/README.md#file-descriptor-3-read-this-if-bats-hangs), you should turn off the file descriptor 3 for the long-running backend job. Then you can write any `goc` subcommand. Remember to kill the `$GOC_PID` in the `teardown_file` function.
+
+## Test covered goc - gocc
+
+We also need to test with the covered gocc in order to get coverage reports.
+
+Most gocc test cases share the same structure, here is the common flow diagram:
+
+```  
+  (1)                                       (2)                                     
+  (wait_profile_backend "xxx" &) --> wait ci-sync exist --> (goc profile -o filtered.cov)--
+                                            |                                             |
+                                            |                                             |
+                                            | (4)                                         |
+  --(gocc --debugcisyncfile ci-sync) --> finish, write ci-sync --> sleep 5; exit          |(5)
+  |                                                                        |              |
+  | (3)                                             (6)                    |              |
+  |------------------------>(goc server &) --------------------------------|              |
+                                  |                                                       |
+                                  ---------------------------------------------------------
+```
+
+1. start the `wait_profile_backend` in the background.
+2. `wait_profile_backend` will block until the file `ci-sync.bak` exists.
+3. the covered `gocc` subcommand start and register to the `goc server`.
+4. the covered `gocc` subcommand run its own logic until finish, as we add the `--debugcisyncfile ci-sync` flag, it will write a file called `ci-sync`, and wait 5 seconds.
+5. `wait_profile_backend` continue to run, and try to get the profile from the `goc server`.
+6. the `goc server` finally call the http API to get the `gocc` profile.

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -29,18 +29,48 @@ teardown_file() {
     kill -9 $GOC_PID
 }
 
+setup() {
+    goc init
+}
+
 @test "test basic goc build command" {
     cd samples/run_for_several_seconds
-    wait_profile_backend "build1"
+    
+    wait_profile_backend "build1" &
+    profile_pid=$!
+
     run gocc build --debug --debugcisyncfile ci-sync.bak;
-    info build output: $output
+    info build1 output: $output
     [ "$status" -eq 0 ]
+
+    wait $profile_pid
 }
 
 @test "test goc build command without debug" {
     cd samples/run_for_several_seconds
-    wait_profile_backend "build2"
+
+    wait_profile_backend "build2" &
+    profile_pid=$!
+
     run gocc build --debugcisyncfile ci-sync.bak;
-    info build output: $output
+    info build2 output: $output
     [ "$status" -eq 0 ]
+
+    wait $profile_pid
+}
+
+@test "test goc build in GOPATH project" {
+    info $PWD
+    export GOPATH=$PWD/samples/simple_gopath_project
+    export GO111MODULE=off
+    cd samples/simple_gopath_project/src/qiniu.com/simple_gopath_project
+
+    wait_profile_backend "build3" &
+    profile_pid=$!
+
+    run gocc build --buildflags="-v" --debug --debugcisyncfile ci-sync.bak;
+    info build3 output: $output
+    [ "$status" -eq 0 ]
+
+    wait $profile_pid
 }

--- a/tests/clear.bats
+++ b/tests/clear.bats
@@ -44,19 +44,25 @@ teardown_file() {
 }
 
 @test "test basic goc clear command" {
-    wait_profile_backend "clear1"
+    wait_profile_backend "clear1" &
+    profile_pid=$!
 
     run gocc clear --debug --debugcisyncfile ci-sync.bak;
     info clear1 output: $output
     [ "$status" -eq 0 ]
-    [[ "$output" == *"coverage counter clear call successfully"* ]]
+    [[ "$output" == *""* ]]
+
+    wait $profile_pid
 }
 
 @test "test clear another center" {
-    wait_profile_backend "clear2"
+    wait_profile_backend "clear2" &
+    profile_pid=$!
 
     run gocc clear --center=http://127.0.0.1:60001 --debug --debugcisyncfile ci-sync.bak;
     info clear2 output: $output
     [ "$status" -eq 0 ]
     [[ "$output" == *"coverage counter clear call successfully"* ]]
+
+    wait $profile_pid
 }

--- a/tests/cover.bats
+++ b/tests/cover.bats
@@ -35,9 +35,16 @@ teardown_file() {
     kill -9 $GOC_PID
 }
 
+setup() {
+    goc init
+}
+
 @test "test basic goc cover command" {
     cd test-temp
-    wait_profile_backend "cover1"
+
+    wait_profile_backend "cover1" &
+    profile_pid=$!
+
     run gocc cover --debug --debugcisyncfile ci-sync.bak;
     info cover1 output: $output
     [ "$status" -eq 0 ]
@@ -46,4 +53,6 @@ teardown_file() {
     info ls output: $output
     [ "$status" -eq 0 ]
     [[ "$output" == *"http_cover_apis_auto_generated.go"* ]]
+
+    wait $profile_pid
 }

--- a/tests/init.bats
+++ b/tests/init.bats
@@ -44,9 +44,12 @@ teardown_file() {
 }
 
 @test "test init command" {
-    wait_profile_backend "init1"
+    wait_profile_backend "init1" &
+    profile_pid=$!
 
     run gocc init --center=http://127.0.0.1:60001 --debug --debugcisyncfile ci-sync.bak;
     info init output: $output
     [ "$status" -eq 0 ]
+
+    wait $profile_pid
 }

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -29,13 +29,22 @@ teardown_file() {
     kill -9 $GOC_PID
 }
 
+setup() {
+    goc init
+}
+
 @test "test basic goc install command" {
     info $PWD
     export GOPATH=$PWD/samples/simple_gopath_project
     export GO111MODULE=off
     cd samples/simple_gopath_project/src/qiniu.com/simple_gopath_project
-    wait_profile_backend "install"
+
+    wait_profile_backend "install" &
+    profile_pid=$!
+
     run gocc install --debug --debugcisyncfile ci-sync.bak;
     info install output: $output
     [ "$status" -eq 0 ]
+
+    wait $profile_pid
 }

--- a/tests/list.bats
+++ b/tests/list.bats
@@ -36,11 +36,14 @@ teardown_file() {
 }
 
 @test "test basic goc list command" {
-    wait_profile_backend "list"
+    wait_profile_backend "list" &
+    profile_pid=$!
 
     run gocc list --debug --debugcisyncfile ci-sync.bak;
     info list output: $output
     [ "$status" -eq 0 ]
     [[ "$output" == *"gocc"* ]]
     [[ "$output" == *"http"* ]]
+
+    wait $profile_pid
 }

--- a/tests/register.bats
+++ b/tests/register.bats
@@ -35,20 +35,31 @@ teardown_file() {
     kill -9 $GOCC_PID
 }
 
+# we need to catch gocc server, so no init
+# setup() {
+#     goc init
+# }
+
 @test "test basic goc register command" {
-    wait_profile_backend "register1"
+    wait_profile_backend "register1" &
+    profile_pid=$!
 
     run gocc register --center=http://127.0.0.1:60001 --name=xyz --address=http://137.0.0.1:666 --debug --debugcisyncfile ci-sync.bak;
-    info register output: $output
+    info register1 output: $output
     [ "$status" -eq 0 ]
     [[ "$output" == *"success"* ]]
+
+    wait $profile_pid
 }
 
 @test "test goc register without port" {
-    wait_profile_backend "register2"
+    wait_profile_backend "register2" &
+    profile_pid=$!
 
     run gocc register --center=http://127.0.0.1:60001 --name=xyz --address=http://137.0.0.1 --debug --debugcisyncfile ci-sync.bak;
-    info register output: $output
+    info register2 output: $output
     [ "$status" -eq 0 ]
     [[ "$output" == *"missing port"* ]]
+
+    wait $profile_pid
 }

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -34,10 +34,14 @@ teardown_file() {
     export GOPATH=$PWD/samples/simple_gopath_project
     export GO111MODULE=off
     cd samples/simple_gopath_project/src/qiniu.com/simple_gopath_project
-    wait_profile_backend "run1"
+
+    wait_profile_backend "run1" &
+    profile_pid=$!
 
     run gocc run . --debug --debugcisyncfile ci-sync.bak;
     info run output: $output
     [ "$status" -eq 0 ]
     [[ "$output" == *"hello, world."* ]]
+
+    wait $profile_pid
 }

--- a/tests/util.sh
+++ b/tests/util.sh
@@ -22,7 +22,8 @@ wait_profile() {
     local timeout=10
     until [[ ${n} -ge ${timeout} ]]
     do
-        # check whether the target port is listened by specific process
+        LS=`ls`
+        info $1, $LS
         if [[ -f ci-sync.bak ]]; then
             break
         fi
@@ -31,9 +32,10 @@ wait_profile() {
     done
     # collect from center
     goc profile -o filtered-$1.cov
+    info "done $1 collect"
 }
 
 wait_profile_backend() {
     rm ci-sync.bak || true
-    coproc { wait_profile $1; }
+    wait_profile $1
 }

--- a/tests/version.bats
+++ b/tests/version.bats
@@ -35,8 +35,11 @@ teardown_file() {
 }
 
 @test "test basic goc version command" {
-    wait_profile_backend "version"
+    wait_profile_backend "version" &
+    profile_pid=$!
 
     run gocc version --debug --debugcisyncfile ci-sync.bak;
     [ "$output" = "(devel)" ]
+
+    wait $profile_pid
 }


### PR DESCRIPTION
1. add README about how to write e2e test case
2. enhance the "file lock sync" logic:
    1. as explained in the README, `wait_profile_backend` executed in the backend
    2. the forground test case **should wait**  `wait_profile_backend`  finish, or different test case's  `wait_profile_backend` may conflict 