### PR TITLE
add support for go.mod contains replace directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.6.2
 	github.com/stretchr/testify v1.5.1
+	golang.org/x/mod v0.3.0
 	golang.org/x/net v0.0.0-20200625001655-4c5254603344
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/tools v0.0.0-20200730221956-1ac65761fe2c

--- a/go.sum
+++ b/go.sum
@@ -822,6 +822,7 @@ golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKG
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -41,7 +41,8 @@ type Build struct {
 	// Project Root:
 	// 1. legacy, root == GOPATH
 	// 2. mod, root == go.mod Dir
-	Target string // the binary name that go build generate
+	ModRoot string // path for go.mod
+	Target  string // the binary name that go build generate
 	// keep compatible with go commands:
 	// go run [build flags] [-exec xprog] package [arguments...]
 	// go build [-o output] [-i] [build flags] [packages]

--- a/pkg/build/gomodules.go
+++ b/pkg/build/gomodules.go
@@ -41,6 +41,14 @@ func (b *Build) cpGoModulesProject() {
 	}
 }
 
+// updateGoModFile rewrites the go.mod file in the temporary directory,
+// if it has a 'replace' directive, and the directive has a relative local path
+// it will be rewritten with a absolute path.
+// ex.
+// suppose original project is located at /path/to/aa/bb/cc, go.mod contains a directive:
+// 'replace github.com/qiniu/bar => ../home/foo/bar'
+// after the project is copied to temporary directory, it should be rewritten as
+// 'replace github.com/qiniu/bar => /path/to/aa/bb/home/foo/bar'
 func (b *Build) updateGoModFile() (updateFlag bool, newModFile []byte, err error) {
 	tempModfile := filepath.Join(b.TmpDir, "go.mod")
 	buf, err := ioutil.ReadFile(tempModfile)
@@ -64,19 +72,19 @@ func (b *Build) updateGoModFile() (updateFlag bool, newModFile []byte, err error
 		if newVersion == "" && !filepath.IsAbs(newPath) {
 			var absPath string
 			fullPath := filepath.Join(b.ModRoot, newPath)
-			absPath, err = filepath.Abs(fullPath)
-			if err != nil {
-				return
-			}
+			absPath, _ = filepath.Abs(fullPath)
+			// DropReplace & AddReplace will not return error
+			// so no need to check the error
 			_ = oriGoModFile.DropReplace(oldPath, oldVersion)
 			_ = oriGoModFile.AddReplace(oldPath, oldVersion, absPath, newVersion)
 			updateFlag = true
 		}
 	}
 	oriGoModFile.Cleanup()
-	newModFile, err = oriGoModFile.Format()
-	if err != nil {
-		return
-	}
+	// Format will not return error, so ignore the returned error
+	// func (f *File) Format() ([]byte, error) {
+	//     return Format(f.Syntax), nil
+	// }
+	newModFile, _ = oriGoModFile.Format()
 	return
 }

--- a/pkg/build/gomodules_test.go
+++ b/pkg/build/gomodules_test.go
@@ -79,6 +79,7 @@ func TestUpdateModFileIfContainsReplace(t *testing.T) {
 
 // test wrong go mod file
 func TestWithWrongGoModFile(t *testing.T) {
+	// go.mod not exist
 	workingDir := filepath.Join(baseDir, "../../tests/samples/xxxxxxxxxxxx/a")
 	b := &Build{
 		TmpDir:  workingDir,

--- a/pkg/build/tmpfolder.go
+++ b/pkg/build/tmpfolder.go
@@ -103,8 +103,8 @@ func (b *Build) mvProjectsToTmp() error {
 		if err != nil {
 			return fmt.Errorf("fail to generate new go.mod: %v", err)
 		}
-		log.Infof("go.mod needs rewrite? %v", updated)
 		if updated {
+			log.Infoln("go.mod needs rewrite")
 			tmpModFile := filepath.Join(b.TmpDir, "go.mod")
 			err := ioutil.WriteFile(tmpModFile, newGoModContent, os.ModePerm)
 			if err != nil {

--- a/pkg/build/tmpfolder.go
+++ b/pkg/build/tmpfolder.go
@@ -134,6 +134,7 @@ func (b *Build) traversePkgsList() (isMod bool, root string, err error) {
 			return
 		}
 		isMod = true
+		b.ModRoot = v.Module.Dir
 		return
 	}
 	log.Error(ErrShouldNotReached)

--- a/pkg/build/tmpfolder.go
+++ b/pkg/build/tmpfolder.go
@@ -76,10 +76,9 @@ func (b *Build) mvProjectsToTmp() error {
 	// Create a new tmp folder
 	err := os.MkdirAll(filepath.Join(b.TmpDir, "src"), os.ModePerm)
 	if err != nil {
-		log.Errorf("Fail to create the temporary build directory. The err is: %v", err)
-		return err
+		return fmt.Errorf("Fail to create the temporary build directory. The err is: %v", err)
 	}
-	log.Printf("Tmp project generated in: %v", b.TmpDir)
+	log.Infof("Tmp project generated in: %v", b.TmpDir)
 
 	// traverse pkg list to get project meta info
 	b.IsMod, b.Root, err = b.traversePkgsList()
@@ -90,7 +89,6 @@ func (b *Build) mvProjectsToTmp() error {
 	// we should get corresponding working directory in temporary directory
 	b.TmpWorkingDir, err = b.getTmpwd()
 	if err != nil {
-		log.Errorf("fail to get workding directory in temporary directory: %v", err)
 		return fmt.Errorf("getTmpwd failed with error: %w", err)
 	}
 	// issue #14
@@ -108,7 +106,7 @@ func (b *Build) mvProjectsToTmp() error {
 		log.Infof("go.mod needs rewrite? %v", updated)
 		if updated {
 			tmpModFile := filepath.Join(b.TmpDir, "go.mod")
-			err := ioutil.WriteFile(tmpModFile, newGoModContent, 0666)
+			err := ioutil.WriteFile(tmpModFile, newGoModContent, os.ModePerm)
 			if err != nil {
 				return fmt.Errorf("fail to update go.mod: %v", err)
 			}

--- a/pkg/build/tmpfolder.go
+++ b/pkg/build/tmpfolder.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -100,6 +101,18 @@ func (b *Build) mvProjectsToTmp() error {
 		b.cpLegacyProject()
 	} else if b.IsMod == true { // go 1.11, 1.12 has no Build.Root
 		b.cpGoModulesProject()
+		updated, newGoModContent, err := b.updateGoModFile()
+		if err != nil {
+			return fmt.Errorf("fail to generate new go.mod: %v", err)
+		}
+		log.Infof("go.mod needs rewrite? %v", updated)
+		if updated {
+			tmpModFile := filepath.Join(b.TmpDir, "go.mod")
+			err := ioutil.WriteFile(tmpModFile, newGoModContent, 0666)
+			if err != nil {
+				return fmt.Errorf("fail to update go.mod: %v", err)
+			}
+		}
 	} else if b.IsMod == false && b.Root == "" {
 		b.TmpWorkingDir = b.TmpDir
 		b.cpNonStandardLegacy()

--- a/tests/build.bats
+++ b/tests/build.bats
@@ -74,3 +74,16 @@ setup() {
 
     wait $profile_pid
 }
+
+@test "test goc build with go.mod project which contains replace directive" {
+    cd samples/gomod_replace_project
+
+    wait_profile_backend "build4" &
+    profile_pid=$!
+
+    run gocc build --debug --debugcisyncfile ci-sync.bak;
+    info build4 output: $output
+    [ "$status" -eq 0 ]
+
+    wait $profile_pid
+}

--- a/tests/samples/gomod_replace_library/bar.go
+++ b/tests/samples/gomod_replace_library/bar.go
@@ -1,0 +1,7 @@
+package foo
+
+import "fmt"
+
+func Bar() {
+	fmt.Println("foo bar")
+}

--- a/tests/samples/gomod_replace_library/go.mod
+++ b/tests/samples/gomod_replace_library/go.mod
@@ -1,0 +1,4 @@
+module qiniu.com/foo
+
+
+go 1.11

--- a/tests/samples/gomod_replace_project/go.mod
+++ b/tests/samples/gomod_replace_project/go.mod
@@ -1,0 +1,7 @@
+module example.com/simple-project
+
+require qiniu.com/foo v0.0.0
+
+replace qiniu.com/foo => ../gomod_replace_library
+
+go 1.11

--- a/tests/samples/gomod_replace_project/main.go
+++ b/tests/samples/gomod_replace_project/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"qiniu.com/foo"
+)
+
+func main() {
+	foo.Bar()
+}

--- a/tests/samples/gomod_samples/a/go.mod
+++ b/tests/samples/gomod_samples/a/go.mod
@@ -1,0 +1,7 @@
+module example.com/gg/a
+
+replace github.com/qiniu/bar => ../home/foo/bar
+
+require (
+	github.com/qiniu/bar v1.0.0
+)

--- a/tests/samples/gomod_samples/a/go.mod
+++ b/tests/samples/gomod_samples/a/go.mod
@@ -1,7 +1,11 @@
 module example.com/gg/a
 
-replace github.com/qiniu/bar => ../home/foo/bar
+replace (
+    github.com/qiniu/bar => ../home/foo/bar
+    github.com/qiniu/bar2 => github.com/baniu/bar3 v1.2.3
+)
 
 require (
 	github.com/qiniu/bar v1.0.0
+    github.com/qiniu/bar2 v1.2.0
 )

--- a/tests/samples/gomod_samples/b/go.mod
+++ b/tests/samples/gomod_samples/b/go.mod
@@ -1,0 +1,7 @@
+module example.com/gg/a
+
+replerace github.com/qiniu/bar => ../home/foo/bar
+
+eggrr (
+	github.com/qiniu/bar v1.0.0
+)


### PR DESCRIPTION
fix #92 
go.mod supports to replace some dependencies with local ones, suppose we have two projects in two directries: gomod_replace_library and gomod_replace_project. 

```
├── gomod_replace_library
│   ├── bar.go
│   └── go.mod
├── gomod_replace_project
│   ├── go.mod
│   └── main.go
```

And go.mod for gomod_replace_project is:

```
module example.com/simple-project

require qiniu.com/foo v0.0.0

replace qiniu.com/foo => ../gomod_replace_library

go 1.11
``` 

If we use goc build/install in `gomod_replace_project` directory, goc will first copy all the content in `gomod_replace_project` to a temporary directory. Then goc will call go build to build the project, but go cannot find the dependency `../gomod_replace_library` from the temporary directory, so we need to rewrite the go.mod to some thing like:

```
module example.com/simple-project

require qiniu.com/foo v0.0.0

replace qiniu.com/foo => /Users/xxx/tests/samples/gomod_replace_library

go 1.11
``` 