### PR TITLE
Fix nil issue when failed to register with coverage center.

### DIFF
--- a/pkg/cover/instrument.go
+++ b/pkg/cover/instrument.go
@@ -208,7 +208,11 @@ func registerSelf(address string) ([]byte, error) {
 		log.Printf("[goc][WARN]error occurred:%v, try again", err)
 		resp, err = http.DefaultClient.Do(req)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if resp != nil {
+			resp.Body.Close()
+		}
+	}()
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to register into coverage center, err:%v", err)

--- a/pkg/cover/instrument.go
+++ b/pkg/cover/instrument.go
@@ -208,15 +208,10 @@ func registerSelf(address string) ([]byte, error) {
 		log.Printf("[goc][WARN]error occurred:%v, try again", err)
 		resp, err = http.DefaultClient.Do(req)
 	}
-	defer func() {
-		if resp != nil {
-			resp.Body.Close()
-		}
-	}()
-
 	if err != nil {
 		return nil, fmt.Errorf("failed to register into coverage center, err:%v", err)
 	}
+	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
When "register" POST request failed, the "resp" will be nil, so we should check the nil before close "resp.Body" in defer.