### PR TITLE
Improve performance of getting filelist to copy

### DIFF
--- a/pkg/build/legacy_test.go
+++ b/pkg/build/legacy_test.go
@@ -17,12 +17,12 @@
 package build
 
 import (
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/qiniu/goc/pkg/cover"
 	"github.com/stretchr/testify/assert"
-	"os"
 )
 
 // copy in cpProject of invalid src, dst name
@@ -79,4 +79,35 @@ func TestCopyDir(t *testing.T) {
 	assert.NoError(t, os.MkdirAll(tmpDir, os.ModePerm))
 	defer os.RemoveAll(tmpDir)
 	assert.NoError(t, b.copyDir(pkg))
+}
+
+func initSlicesForTest() *cover.Package {
+	var pkg cover.Package
+	pkg.GoFiles = []string{"a1.go", "b1.go", "c1.go"}
+	pkg.CompiledGoFiles = []string{"a2.go", "b2.go", "c2.go"}
+	pkg.IgnoredGoFiles = []string{"a3.go", "b3.go", "c3.go"}
+	pkg.CFiles = []string{"a4.go", "b4.go", "c4.go"}
+	pkg.CXXFiles = []string{"a5.go", "b5.go", "c5.go"}
+	pkg.MFiles = []string{"a6.go", "b6.go", "c6.go"}
+	pkg.HFiles = []string{"a7.go", "b7.go", "c7.go"}
+	pkg.FFiles = []string{"a8.go", "b8.go", "c8.go"}
+	pkg.SFiles = []string{"a9.go", "b9.go", "c9.go"}
+	pkg.SwigCXXFiles = []string{"a10.go", "b10.go", "c10.go"}
+	pkg.SwigFiles = []string{"a11.go", "b11.go", "c11.go"}
+	pkg.SysoFiles = []string{"a12.go", "b12.go", "c12.go"}
+
+	return &pkg
+}
+
+// benchmark getFileListNeedsCopy
+// goos: darwin
+// goarch: amd64
+// pkg: github.com/qiniu/goc/pkg/build
+// BenchmarkGetFileList-4           3884557               298 ns/op             576 B/op          1 allocs/op
+func BenchmarkGetFileList(b *testing.B) {
+	//var files []string
+	pkg := initSlicesForTest()
+	for n := 0; n < b.N; n++ {
+		getFileListNeedsCopy(pkg)
+	}
 }


### PR DESCRIPTION
`arr = append(arr, 1)` may allocate a new space,
in this PR, it improve performance by allocating new space only one time.

original perf data:
```
goos: darwin
goarch: amd64
pkg: github.com/qiniu/goc/pkg/build
BenchmarkGetFileList-4           1535029               778 ns/op            1488 B/op          5 allocs/op
```
new perf data:
```
goos: darwin
goarch: amd64
pkg: github.com/qiniu/goc/pkg/build
BenchmarkGetFileList-4           3884557               298 ns/op             576 B/op          1 allocs/op
```

The new function use less time and fewer memory.