### PR TITLE
feat: 使用mod=vendor时候不应该更新go.mod文件

### DIFF
--- a/pkg/build/gomodules.go
+++ b/pkg/build/gomodules.go
@@ -55,7 +55,7 @@ func (b *Build) cpGoModulesProject() {
 func (b *Build) updateGoModFile() (updateFlag bool, newModFile []byte, err error) {
 	// use buildflags `-mod=vendor` and exist vendor folder, should not update go.mod
 	if _, err := os.Stat(path.Join(b.ModRoot, "vendor")); err == nil && strings.Contains(b.BuildFlags, "-mod=vendor") {
-	   return
+		return
 	}
 	tempModfile := filepath.Join(b.TmpDir, "go.mod")
 	buf, err := ioutil.ReadFile(tempModfile)

--- a/pkg/build/gomodules.go
+++ b/pkg/build/gomodules.go
@@ -102,10 +102,7 @@ func (b *Build) shouldUpdateGoMod() bool {
 	if !b.IsMod {
 		return false
 	}
-	if !strings.Contains(b.BuildFlags, "-mod=vendor") {
-		return false
-	}
-	if _, err := os.Stat(path.Join(b.ModRoot, "vendor")); err != nil {
+	if _, err := os.Stat(path.Join(b.ModRoot, "vendor")); err == nil && strings.Contains(b.BuildFlags, "-mod=vendor") {
 		return false
 	}
 	return true

--- a/pkg/build/gomodules.go
+++ b/pkg/build/gomodules.go
@@ -54,7 +54,7 @@ func (b *Build) cpGoModulesProject() {
 // 'replace github.com/qiniu/bar => /path/to/aa/bb/home/foo/bar'
 func (b *Build) updateGoModFile() (updateFlag bool, newModFile []byte, err error) {
 	// use buildflags `-mod=vendor` and exist vendor folder, should not update go.mod
-	if _, err := os.Stat(path.Join(b.ModRoot, "vendor")); err == nil && strings.Contains(b.BuildFlags, "-mod=vendor") {
+	if _, err1 := os.Stat(path.Join(b.ModRoot, "vendor")); err1 == nil && strings.Contains(b.BuildFlags, "-mod=vendor") {
 		return
 	}
 	tempModfile := filepath.Join(b.TmpDir, "go.mod")

--- a/pkg/build/gomodules.go
+++ b/pkg/build/gomodules.go
@@ -53,8 +53,9 @@ func (b *Build) cpGoModulesProject() {
 // after the project is copied to temporary directory, it should be rewritten as
 // 'replace github.com/qiniu/bar => /path/to/aa/bb/home/foo/bar'
 func (b *Build) updateGoModFile() (updateFlag bool, newModFile []byte, err error) {
-	if !b.shouldUpdateGoMod() {
-		return
+	// use buildflags `-mod=vendor` and exist vendor folder, should not update go.mod
+	if _, err := os.Stat(path.Join(b.ModRoot, "vendor")); err == nil && strings.Contains(b.BuildFlags, "-mod=vendor") {
+	   return
 	}
 	tempModfile := filepath.Join(b.TmpDir, "go.mod")
 	buf, err := ioutil.ReadFile(tempModfile)
@@ -93,17 +94,4 @@ func (b *Build) updateGoModFile() (updateFlag bool, newModFile []byte, err error
 	// }
 	newModFile, _ = oriGoModFile.Format()
 	return
-}
-
-// shouldUpdateGoMod return should update go.mod file
-// 1. b.isMod = false
-// 2. BuildFlags has `-mod=vendor` and exist vendor folder
-func (b *Build) shouldUpdateGoMod() bool {
-	if !b.IsMod {
-		return false
-	}
-	if _, err := os.Stat(path.Join(b.ModRoot, "vendor")); err == nil && strings.Contains(b.BuildFlags, "-mod=vendor") {
-		return false
-	}
-	return true
 }


### PR DESCRIPTION
使用`go build -mod=vendor`编译的时候，不应该去更新go.mod文件, 因为相关依赖都在vendor文件里了，如果更新了go.mod文件会导致`vendor`目录和`go.mod`文件内容不一致