### PR TITLE
only change gopath when newGopath not exists in legacy mode

### DIFF
--- a/pkg/build/tmpfolder.go
+++ b/pkg/build/tmpfolder.go
@@ -50,7 +50,7 @@ func (b *Build) MvProjectsToTmp() error {
 		return err
 	}
 	b.OriGOPATH = os.Getenv("GOPATH")
-	if b.IsMod == true {
+	if b.IsMod {
 		b.NewGOPATH = ""
 	} else if b.OriGOPATH == "" {
 		b.NewGOPATH = b.TmpDir
@@ -61,7 +61,7 @@ func (b *Build) MvProjectsToTmp() error {
 	// this kind of project does not have a pkg.Root value
 	// go 1.11, 1.12 has no pkg.Root,
 	// so add b.IsMod == false as secondary judgement
-	if b.Root == "" && b.IsMod == false {
+	if b.NewGOPATH == "" && b.Root == "" && !b.IsMod {
 		b.NewGOPATH = b.OriGOPATH
 	}
 	log.Infof("New GOPATH: %v", b.NewGOPATH)

--- a/pkg/build/tmpfolder_test.go
+++ b/pkg/build/tmpfolder_test.go
@@ -88,15 +88,15 @@ func TestNewDirParseInModProject(t *testing.T) {
 // Test #14
 func TestLegacyProjectNotInGoPATH(t *testing.T) {
 	workingDir := filepath.Join(baseDir, "../../tests/samples/simple_gopath_project/src/qiniu.com/simple_gopath_project")
-	gopath := ""
+	gopath := "/abc"
 
 	fmt.Println(gopath)
 	os.Setenv("GOPATH", gopath)
 	os.Setenv("GO111MODULE", "off")
 
 	b, _ := NewBuild("", []string{"."}, workingDir, "")
-	if b.OriGOPATH != b.NewGOPATH {
-		t.Fatalf("New GOPATH should be same with old GOPATH, for this kind of project. New: %v, old: %v", b.NewGOPATH, b.OriGOPATH)
+	if !strings.HasSuffix(b.NewGOPATH, b.OriGOPATH) {
+		t.Fatalf("New GOPATH should contains old GOPATH for this kind of project. New: %v, old: %v", b.NewGOPATH, b.OriGOPATH)
 	}
 
 	_, err := os.Stat(filepath.Join(b.TmpDir, "main.go"))


### PR DESCRIPTION
fix #247 