### PR TITLE
ci: build release artifacts for more architectures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,10 @@
-on: 
+on:
   release:
     types: [published,edited]
 name: Build Release
 jobs:
-  release-linux-amd64:
-    name: release linux/amd64
+  release-darwin-amd64:
+    name: release darwin/amd64
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
@@ -18,7 +18,24 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GOARCH: amd64
-        GOOS: linux
+        GOOS: darwin
+
+  release-darwin-arm64:
+    name: release darwin/arm64
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.18.x
+    - name: compile and release
+      run: |
+        ./ci-build.sh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GOARCH: arm64
+        GOOS: darwin
 
   release-linux-386:
     name: release linux/386
@@ -37,8 +54,8 @@ jobs:
         GOARCH: "386"
         GOOS: linux
 
-  release-darwin-amd64:
-    name: release darwin/amd64
+  release-linux-amd64:
+    name: release linux/amd64
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
@@ -52,4 +69,55 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GOARCH: amd64
-        GOOS: darwin
+        GOOS: linux
+
+  release-linux-arm64:
+    name: release linux/arm64
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.18.x
+    - name: compile and release
+      run: |
+        ./ci-build.sh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GOARCH: arm64
+        GOOS: linux
+
+  release-linux-mips64le:
+    name: release linux/mips64le
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.18.x
+    - name: compile and release
+      run: |
+        ./ci-build.sh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GOARCH: mips64le
+        GOOS: linux
+
+  release-linux-riscv64:
+    name: release linux/riscv64
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.18.x
+    - name: compile and release
+      run: |
+        ./ci-build.sh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GOARCH: riscv64
+        GOOS: linux


### PR DESCRIPTION
- reorder alphabetically
- add builds for popular hardware:
    - darwin/arm64, linux/arm64 (Apple Silicon and other AArch64 devices)
    - linux/mips64le (Loongson devices before loong64 transition)
    - linux/riscv64 (emerging architecture)