### PR TITLE
fix:fix server address error when running in k8s

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -42,20 +42,17 @@ goc server --port=localhost:8080
 		if err != nil {
 			log.Fatalf("New file based server failed, err: %v", err)
 		}
-		if netwrok == "direct" {
-			server.NetworkType = "direct"
-		} else {
-			server.NetworkType = "default"
-		}
+		server.IPRevise = iprevise
 		server.Run(port)
 	},
 }
 
-var port, localPersistence, netwrok string
+var port, localPersistence string
+var iprevise bool
 
 func init() {
 	serverCmd.Flags().StringVarP(&port, "port", "", ":7777", "listen port to start a coverage host center")
 	serverCmd.Flags().StringVarP(&localPersistence, "local-persistence", "", "_svrs_address.txt", "the file to save services address information")
-	serverCmd.Flags().StringVarP(&netwrok, "network", "", "default", "setting the network type(default:regist server use proxy or under nat、same network ect,direct:use register request parm)")
+	serverCmd.Flags().BoolVarP(&iprevise, "ip_revise", "", true, "setting the network type(default:regist server use proxy or under nat、same network ect,direct:use register request parm)")
 	rootCmd.AddCommand(serverCmd)
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -17,9 +17,10 @@
 package cmd
 
 import (
+	"log"
+
 	"github.com/qiniu/goc/pkg/cover"
 	"github.com/spf13/cobra"
-	"log"
 )
 
 var serverCmd = &cobra.Command{
@@ -41,14 +42,20 @@ goc server --port=localhost:8080
 		if err != nil {
 			log.Fatalf("New file based server failed, err: %v", err)
 		}
+		if netwrok == "direct" {
+			server.NetworkType = "direct"
+		} else {
+			server.NetworkType = "default"
+		}
 		server.Run(port)
 	},
 }
 
-var port, localPersistence string
+var port, localPersistence, netwrok string
 
 func init() {
 	serverCmd.Flags().StringVarP(&port, "port", "", ":7777", "listen port to start a coverage host center")
 	serverCmd.Flags().StringVarP(&localPersistence, "local-persistence", "", "_svrs_address.txt", "the file to save services address information")
+	serverCmd.Flags().StringVarP(&netwrok, "network", "", "default", "setting the network type(default:regist server use proxy or under nat、same network ect,direct:use register request parm)")
 	rootCmd.AddCommand(serverCmd)
 }

--- a/pkg/cover/server.go
+++ b/pkg/cover/server.go
@@ -134,6 +134,9 @@ func (s *server) registerService(c *gin.Context) {
 	} else if u.Host == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "address is empty"})
 		return
+	} else if u.Hostname() == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "empty host name"})
+		return
 	}
 
 	address := s.Store.Get(service.Name)

--- a/pkg/cover/server_test.go
+++ b/pkg/cover/server_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -175,7 +176,7 @@ func TestRegisterService(t *testing.T) {
 
 	// regist with empty host(in direct mode,empty must fail,default is success)
 	// in default,use request realhost as host,use 80 as port
-	server.NetworkType = "direct"
+	server.IPRevise = false
 	data = url.Values{}
 	data.Set("name", "aaa")
 	data.Set("address", "http://")
@@ -209,14 +210,14 @@ func TestRegisterService(t *testing.T) {
 	data = url.Values{}
 	data.Set("name", "aaa")
 	data.Set("address", "http://")
-	data.Set("network", "default")
+	data.Set("iprevise", "true")
 	w = httptest.NewRecorder()
 	req, _ = http.NewRequest("POST", "/v1/cover/register", strings.NewReader(data.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	server.NetworkType = "default" //use clientip and default port(80)
+	server.IPRevise = true //use clientip and default port(80)
 	data = url.Values{}
 	data.Set("name", "aaa")
 	data.Set("address", "http://")
@@ -246,9 +247,9 @@ func TestRegisterService(t *testing.T) {
 
 	// register with store failure
 	expectedS := ServiceUnderTest{
-		Name:    "foo",
-		Address: "http://:64444", // the real IP is empty in unittest, so server will get a empty one
-		Network: server.NetworkType,
+		Name:     "foo",
+		Address:  "http://:64444", // the real IP is empty in unittest, so server will get a empty one
+		IPRevise: strconv.FormatBool(server.IPRevise),
 	}
 	testObj := new(MockStore)
 	testObj.On("Get", "foo").Return([]string{"http://127.0.0.1:66666"})

--- a/pkg/cover/store_test.go
+++ b/pkg/cover/store_test.go
@@ -18,12 +18,14 @@ package cover
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestLocalStore(t *testing.T) {
+	os.Remove("_svrs_address.txt") //remove _svrs_address.txt file，make sure no data effect this unit test
 	localStore, err := NewFileStore("_svrs_address.txt")
 	assert.NoError(t, err)
 	var tc1 = ServiceUnderTest{

--- a/tests/register.bats
+++ b/tests/register.bats
@@ -59,7 +59,7 @@ teardown_file() {
     run gocc register --center=http://127.0.0.1:60001 --name=xyz --address=http://137.0.0.1 --debug --debugcisyncfile ci-sync.bak;
     info register2 output: $output
     [ "$status" -eq 0 ]
-    [[ "$output" == *"missing port"* ]]
+    [[ "$output" != *"missing port"* ]]
 
     wait $profile_pid
 }


### PR DESCRIPTION
when goc server running  in k8s
client register uri while be transform to is proxy address
in fact,there is no need to transform

add address uri check,make sure address parm is a complete uri