### PR TITLE
fix duplicate import of global var path in symlink file

### DIFF
--- a/pkg/cover/internal/tool/cover.go
+++ b/pkg/cover/internal/tool/cover.go
@@ -6,6 +6,8 @@ package tool
 
 import (
 	"bytes"
+	"strings"
+
 	// "flag"
 	"fmt"
 	"go/ast"
@@ -342,6 +344,8 @@ func Annotate(name string, mode string, varVar string, globalCoverVarImportPath 
 
 	if bytes.Equal(content, newContent) {
 		log.Info("no cover var injected for: ", name)
+	} else if strings.Contains(string(file.content), globalCoverVarImportPath) {
+		log.Info("global cover var already imported for: ", name)
 	} else {
 		// reback to the beginning
 		file.astFile, _ = parser.ParseFile(fset, name, content, parser.ParseComments)


### PR DESCRIPTION
eg. main.go -> cmd/myproject/run.go

When run `goc build .`, redeclared error will be reported. 
In main.go, the global var path is duplicated imported as follows:
 `package main; import . "myproject/src/gocbuild235e80d276dc"; import . "myproject/src/gocbuild234e80d276dc"`

These two files treaded as two unrelated files in result of `go list` command, so goc imports the global var package twice. 