### PR TITLE
fix:兼容多module，main不在逻辑module中的情况

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -83,6 +83,7 @@ func runBuild(args []string, wd string) {
 		ModRootPath:              gocBuild.ModRootPath,
 		OneMainPackage:           true, // it is a go build
 		GlobalCoverVarImportPath: gocBuild.GlobalCoverVarImportPath,
+		CoverModName:             "coverPackageMod",
 	}
 	err = cover.Execute(ci)
 	if err != nil {

--- a/cmd/cover.go
+++ b/cmd/cover.go
@@ -53,6 +53,7 @@ func runCover(target string) {
 		Center:         center,
 		Singleton:      singleton,
 		OneMainPackage: false,
+		CoverModName:   "coverPackageMod",
 	}
 	_ = cover.Execute(ci)
 }

--- a/pkg/build/gomodules.go
+++ b/pkg/build/gomodules.go
@@ -78,7 +78,8 @@ func (b *Build) updateGoModFile() (updateFlag bool, newModFile []byte, err error
 		// absolute path no need to rewrite
 		if newVersion == "" && !filepath.IsAbs(newPath) {
 			var absPath string
-			fullPath := filepath.Join(b.ModRoot, newPath)
+			//替换原路径为目标路径
+			fullPath := filepath.Join(b.TmpDir, newPath)
 			absPath, _ = filepath.Abs(fullPath)
 			// DropReplace & AddReplace will not return error
 			// so no need to check the error


### PR DESCRIPTION
根据项目版本去生成符合版本的cover module的版本，修改获取所有增加函数ListPackagesInAllModul替换cover/cover.go中Execute函数用到的ListPackages函数去找到多module下的packages